### PR TITLE
Create the on_gem_release event:

### DIFF
--- a/lib/smart_todo.rb
+++ b/lib/smart_todo.rb
@@ -17,5 +17,6 @@ module SmartTodo
 
   module Events
     autoload :Date,                   'smart_todo/events/date'
+    autoload :GemRelease,             'smart_todo/events/gem_release'
   end
 end

--- a/lib/smart_todo/events.rb
+++ b/lib/smart_todo/events.rb
@@ -7,5 +7,9 @@ module SmartTodo
     def on_date(date)
       Date.met?(date)
     end
+
+    def on_gem_release(gem_name, version)
+      GemRelease.new(gem_name, version).met?
+    end
   end
 end

--- a/lib/smart_todo/events/gem_release.rb
+++ b/lib/smart_todo/events/gem_release.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+
+module SmartTodo
+  module Events
+    class GemRelease
+      def initialize(gem_name, version)
+        @gem_name = gem_name
+        @version = version
+      end
+
+      def met?
+        response = client.get("/api/v1/versions/#{@gem_name}.json")
+
+        if response.code_type < Net::HTTPClientError
+          error_message
+        elsif version_released?(response.body)
+          message
+        else
+          false
+        end
+      end
+
+      def error_message
+        "The gem *#{@gem_name}* doesn't seem to exist"
+      end
+
+      def message
+        "The gem *#{@gem_name}* was released to version *#{@version}*"
+      end
+
+      private
+
+      def version_released?(gem_versions)
+        JSON.parse(gem_versions).find { |gem| gem['number'] == @version }
+      end
+
+      def client
+        @client ||= Net::HTTP.new('rubygems.org', Net::HTTP.https_default_port).tap do |client|
+          client.use_ssl = true
+        end
+      end
+    end
+  end
+end

--- a/test/smart_todo/events/gem_release_test.rb
+++ b/test/smart_todo/events/gem_release_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SmartTodo
+  module Events
+    class GemReleaseTest < Minitest::Test
+      def test_when_gem_is_released
+        stub_request(:get, /rubygems.org/)
+          .to_return(body: JSON.dump([{ number: '1.2.0' }]))
+
+        assert_equal("The gem *foo* was released to version *1.2.0*", GemRelease.new('foo', '1.2.0').met?)
+      end
+
+      def test_when_gem_is_not_yet_released
+        stub_request(:get, /rubygems.org/)
+          .to_return(body: JSON.dump([{ number: '1.2.0' }, { number: '1.2.1' }]))
+
+        assert_equal(false, GemRelease.new('foo', '1.3.0').met?)
+      end
+
+      def test_when_gem_does_not_exist
+        stub_request(:get, /rubygems.org/)
+          .to_return(status: 404)
+
+        assert_equal("The gem *foo* doesn't seem to exist", GemRelease.new('foo', '1.3.0').met?)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Create the on_gem_release event:

- User will be able to be warned when a todo related to the release
  of a gem comes to expiration.

  A concrete example is to have to write a monkeypatch in your app
  and have to be reminded to remove it when a gem is released with
  a new version that has the feature/bug fix you need.

  The declaration is as follow

  ```ruby
  # @smart_todo on_gem_release('rails', '5.2.0')
  ```

FYI @casperisfine @rafaelfranca 