### PR TITLE
Create the on_pull_request_close/on_issue_close event:

### DIFF
--- a/lib/smart_todo.rb
+++ b/lib/smart_todo.rb
@@ -18,5 +18,6 @@ module SmartTodo
   module Events
     autoload :Date,                   'smart_todo/events/date'
     autoload :GemRelease,             'smart_todo/events/gem_release'
+    autoload :PullRequestClose,       'smart_todo/events/pull_request_close'
   end
 end

--- a/lib/smart_todo/events.rb
+++ b/lib/smart_todo/events.rb
@@ -11,5 +11,10 @@ module SmartTodo
     def on_gem_release(gem_name, version)
       GemRelease.new(gem_name, version).met?
     end
+
+    def on_pull_request_closed(organization, repo, pr_number)
+      PullRequestClosed.new(organization, repo, pr_number).met?
+    end
+    alias_method :on_issue_close, :on_pull_request_closed
   end
 end

--- a/lib/smart_todo/events/pull_request_close.rb
+++ b/lib/smart_todo/events/pull_request_close.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+
+module SmartTodo
+  module Events
+    class PullRequestClose
+      TOKEN_ENV = 'SMART_TODO_GITHUB_TOKEN'
+
+      def initialize(organization, repo, pr_number)
+        @url = "/repos/#{organization}/#{repo}/pulls/#{pr_number}"
+        @organization = organization
+        @repo = repo
+        @pr_number = pr_number
+      end
+
+      def met?
+        response = client.get(@url, default_headers)
+
+        if response.code_type < Net::HTTPClientError
+          error_message
+        elsif pull_request_closed?(response.body)
+          message
+        else
+          false
+        end
+      end
+
+      def error_message
+        <<~EOM
+          I can't retrieve the information from the PR or Issue *#{@pr_number}* in the
+          *#{@organization}/#{@repo}* repository.
+
+          If the repository is a private one, make sure to export the `#{TOKEN_ENV}`
+          environment variable with a correct GitHub token.
+        EOM
+      end
+
+      def message
+        <<~EOM
+          The Pull Request or Issue *#{@pr_number}* in the *#{@organization}/#{@repo}* repository
+          is now closed, your TODO is ready to be addressed.
+        EOM
+      end
+
+      private
+
+      def client
+        @client ||= Net::HTTP.new('api.github.com', Net::HTTP.https_default_port).tap do |client|
+          client.use_ssl = true
+        end
+      end
+
+      def pull_request_closed?(pull_request)
+        JSON.parse(pull_request)['state'] == 'closed'
+      end
+
+      def default_headers
+        {
+          'Accept' => 'application/vnd.github.v3+json',
+          'Authorization' => "token #{ENV[TOKEN_ENV]}",
+        }
+      end
+    end
+  end
+end

--- a/test/smart_todo/events/pull_request_close_test.rb
+++ b/test/smart_todo/events/pull_request_close_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SmartTodo
+  module Events
+    class PullRequestCloseTest < Minitest::Test
+      def test_when_pull_request_is_close
+        stub_request(:get, /api.github.com/)
+          .to_return(body: JSON.dump(state: 'closed'))
+
+        expected = <<~EOM
+          The Pull Request or Issue *123* in the *rails/rails* repository
+          is now closed, your TODO is ready to be addressed.
+        EOM
+        assert_equal(expected, PullRequestClose.new('rails', 'rails', '123').met?)
+      end
+
+      def test_when_pull_request_is_open
+        stub_request(:get, /api.github.com/)
+          .to_return(body: JSON.dump(state: 'open'))
+
+        assert_equal(false, PullRequestClose.new('rails', 'rails', '123').met?)
+      end
+
+      def test_when_gem_does_not_exist
+        stub_request(:get, /api.github.com/)
+          .to_return(status: 404)
+
+        expected = <<~EOM
+          I can't retrieve the information from the PR or Issue *123* in the
+          *rails/rails* repository.
+
+          If the repository is a private one, make sure to export the `SMART_TODO_GITHUB_TOKEN`
+          environment variable with a correct GitHub token.
+        EOM
+
+        assert_equal(expected, PullRequestClose.new('rails', 'rails', '123').met?)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Create the on_pull_request_close/on_issue_close event:

- User will be able to be warned when a todo related to the release
  of a gem comes to expiration.

  A concrete example is to have to write a monkeypatch in your app
  and have to be reminded to remove it when a gem is released with
  a new version that has the feature/bug fix you need.

  The declaration is as follow

  ```ruby
    # @smart_todo on_pull_request_close('rails', 'rails', '123')
    # @smart_todo on_issue_close('rails', 'rails', '123')
  ```

  If the repo is a private one the user has to export a GitHub token
  with the `repo` scope.

cc/ @rafaelfranca @casperisfine 