### PR TITLE
Modify the `GemReleaseEvent` to accept requirements instead:

### DIFF
--- a/lib/smart_todo/events.rb
+++ b/lib/smart_todo/events.rb
@@ -8,8 +8,8 @@ module SmartTodo
       Date.met?(date)
     end
 
-    def on_gem_release(gem_name, version)
-      GemRelease.new(gem_name, version).met?
+    def on_gem_release(gem_name, *requirements)
+      GemRelease.new(gem_name, requirements).met?
     end
 
     def on_pull_request_closed(organization, repo, pr_number)

--- a/lib/smart_todo/events/gem_release.rb
+++ b/lib/smart_todo/events/gem_release.rb
@@ -6,9 +6,9 @@ require 'json'
 module SmartTodo
   module Events
     class GemRelease
-      def initialize(gem_name, version)
+      def initialize(gem_name, requirements)
         @gem_name = gem_name
-        @version = version
+        @requirements = Gem::Requirement.new(requirements)
       end
 
       def met?
@@ -16,8 +16,8 @@ module SmartTodo
 
         if response.code_type < Net::HTTPClientError
           error_message
-        elsif version_released?(response.body)
-          message
+        elsif (gem = version_released?(response.body))
+          message(gem['number'])
         else
           false
         end
@@ -27,14 +27,16 @@ module SmartTodo
         "The gem *#{@gem_name}* doesn't seem to exist, I can't determine if your TODO is ready to be addressed."
       end
 
-      def message
-        "The gem *#{@gem_name}* was released to version *#{@version}* and your TODO is now ready to be addressed."
+      def message(version_number)
+        "The gem *#{@gem_name}* was released to version *#{version_number}* and your TODO is now ready to be addressed."
       end
 
       private
 
       def version_released?(gem_versions)
-        JSON.parse(gem_versions).find { |gem| gem['number'] == @version }
+        JSON.parse(gem_versions).find do |gem|
+          @requirements.satisfied_by?(Gem::Version.new(gem['number']))
+        end
       end
 
       def client

--- a/test/smart_todo/events/gem_release_test.rb
+++ b/test/smart_todo/events/gem_release_test.rb
@@ -13,6 +13,22 @@ module SmartTodo
         assert_equal(expected, GemRelease.new('foo', '1.2.0').met?)
       end
 
+      def test_with_pessimistic_constraint
+        stub_request(:get, /rubygems.org/)
+          .to_return(body: JSON.dump([{ number: '1.2.0' }]))
+
+        expected = 'The gem *foo* was released to version *1.2.0* and your TODO is now ready to be addressed.'
+        assert_equal(expected, GemRelease.new('foo', '~> 1.1').met?)
+      end
+
+      def test_with_multiple_constraints
+        stub_request(:get, /rubygems.org/)
+          .to_return(body: JSON.dump([{ number: '3.4.6' }]))
+
+        expected = 'The gem *foo* was released to version *3.4.6* and your TODO is now ready to be addressed.'
+        assert_equal(expected, GemRelease.new('foo', ['> 3.4.3', '< 4']).met?)
+      end
+
       def test_when_gem_is_not_yet_released
         stub_request(:get, /rubygems.org/)
           .to_return(body: JSON.dump([{ number: '1.2.0' }, { number: '1.2.1' }]))


### PR DESCRIPTION
Modify the `GemReleaseEvent` to accept requirements instead:

- Instead of expecting a specific version, it's more useful to have
  a list of version requirements.

  A user might not know if the next release if gonna be a bump,
  a minor or a major. By using requirements version, this is more
  flexible.