### PR TITLE
Create a SmartTodo cop to restrict usage of regular todo comment:

### DIFF
--- a/lib/smart_todo_cop.rb
+++ b/lib/smart_todo_cop.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'smart_todo/parser/metadata_parser'
+
+module RuboCop
+  module Cop
+    module SmartTodo
+      class SmartTodoCop < Cop
+        MSG = "Don't write regular TODO comments. Write SmartTodo compatible syntax comments." \
+              "For more info please look at https://github.com/shopify/smart_todo"
+
+        def investigate(processed_source)
+          processed_source.comments.each do |comment|
+            next unless comment.text.start_with?(/#\sTODO/)
+            next if smart_todo?(comment.text)
+
+            add_offense(comment)
+          end
+        end
+
+        def smart_todo?(comment)
+          metadata = ::SmartTodo::Parser::MetadataParser.parse(comment.gsub(/^#/, ''))
+
+          metadata.events.any?
+        end
+      end
+    end
+  end
+end

--- a/smart_todo.gemspec
+++ b/smart_todo.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("rake", "~> 10.0")
   spec.add_development_dependency("minitest", "~> 5.0")
   spec.add_development_dependency("webmock")
+  spec.add_development_dependency("rubocop")
 end

--- a/test/smart_todo/smart_todo_cop_test.rb
+++ b/test/smart_todo/smart_todo_cop_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rubocop'
+require 'rubocop/rspec/expect_offense'
+require 'smart_todo_cop'
+
+module SmartTodo
+  class SmartTodoCopTest < Minitest::Test
+    def test_add_offense_when_todo_is_a_regular_todo
+      expect_offense(<<~RUBY)
+        # TODO: Do this on January first
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{expected_message}
+        def hello
+        end
+      RUBY
+    end
+
+    def test_add_offense_when_todo_is_a_smart_todo_but_malformated
+      expect_offense(<<~RUBY)
+        # TODO(date('2019-08-04'), to: 'john@example.com')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{expected_message}
+        def hello
+        end
+      RUBY
+    end
+
+    def test_does_not_add_offense_when_todo_is_a_smart_todo
+      expect_no_offense(<<~RUBY)
+        # TODO(on: date('2019-08-04'), to: 'john@example.com')
+        def hello
+        end
+      RUBY
+    end
+
+    def test_does_not_add_offense_when_comment_is_not_a_todo
+      expect_no_offense(<<~RUBY)
+        # @return [Void]
+        def hello
+        end
+      RUBY
+    end
+
+    private
+
+    def expected_message
+      "Don't write regular TODO comments. Write SmartTodo compatible syntax comments." \
+              "For more info please look at https://github.com/shopify/smart_todo"
+    end
+
+    def expect_offense(source)
+      annotated_source = RuboCop::RSpec::ExpectOffense::AnnotatedSource.parse(source)
+      investigate(annotated_source.plain_source)
+
+      actual_annotations = annotated_source.with_offense_annotations(cop.offenses)
+      assert_equal(actual_annotations.to_s, annotated_source.to_s)
+    end
+    alias_method :expect_no_offense, :expect_offense
+
+    def investigate(source, ruby_version = 2.5, file = '(file)')
+      processed_source = RuboCop::ProcessedSource.new(source, ruby_version, file)
+
+      RuboCop::Cop::Commissioner.new([cop], [], raise_error: true).tap do |commissioner|
+        commissioner.investigate(processed_source)
+      end
+    end
+
+    def cop
+      @cop ||= RuboCop::Cop::SmartTodo::SmartTodoCop.new
+    end
+  end
+end


### PR DESCRIPTION
- This cop will emit a warning when someone writes a regular style
  TODO comment.

  In order for application to use this cop, they'll have to require it
  manually when they add the gem, I don't want to add it by default
  on people's app.

  ```ruby
    gem 'smart_todo', require: 'smart_todo_cop'
  ```