### PR TITLE
Fix crash when file is ASCII encoded:

### DIFF
--- a/lib/smart_todo/cli.rb
+++ b/lib/smart_todo/cli.rb
@@ -50,7 +50,7 @@ module SmartTodo
     end
 
     def parse_file(file)
-      Parser::CommentParser.new(File.read(file)).parse.each do |todo_node|
+      Parser::CommentParser.new(File.read(file, encoding: 'UTF-8')).parse.each do |todo_node|
         event_message = nil
         event_met = todo_node.metadata.events.find do |event|
           event_message = Events.public_send(event.method_name, *event.arguments)

--- a/test/smart_todo/cli_test.rb
+++ b/test/smart_todo/cli_test.rb
@@ -88,5 +88,30 @@ module SmartTodo
 
       assert_not_requested(:post, /chat.postMessage/)
     end
+
+    def test_ascii_encoded_file_with_utf8_characters_can_be_parsed_correctly
+      previous_encoding = Encoding.default_external
+      Encoding.default_external = 'US-ASCII'
+
+      cli = CLI.new
+      ruby_code = <<~EOM
+        # See "市区町村名"
+        def hello
+        end
+
+        # TODO(on: date('2070-03-02'), to: '#general')
+        #   See "市区町村名"
+        def hello
+        end
+      EOM
+
+      generate_ruby_file(ruby_code) do |file|
+        cli.run([file.path, '--slack_token', '123', '--fallback_channel', '#general"'])
+      end
+
+      assert_not_requested(:post, /chat.postMessage/)
+    ensure
+      Encoding.default_external = previous_encoding
+    end
   end
 end


### PR DESCRIPTION
- Depending on your environment, the `Encoding.default_external` can
  be set to `US-ASCII` (like it's the case on our CI).

  For files that contain UTF-8 characters, SmartTodo would crash.

  This commit fixes that, by passing the `encoding` option when
  reading the file.