### PR TITLE
Modify the cop if a SmartTodo has no assignee:

### DIFF
--- a/lib/smart_todo_cop.rb
+++ b/lib/smart_todo_cop.rb
@@ -29,7 +29,7 @@ module RuboCop
         def smart_todo?(comment)
           metadata = ::SmartTodo::Parser::MetadataParser.parse(comment.gsub(/^#/, ''))
 
-          metadata.events.any?
+          metadata.events.any? && metadata.assignee
         end
       end
     end

--- a/test/smart_todo/smart_todo_cop_test.rb
+++ b/test/smart_todo/smart_todo_cop_test.rb
@@ -25,6 +25,15 @@ module SmartTodo
       RUBY
     end
 
+    def test_add_offense_when_todo_has_an_event_but_no_assignee
+      expect_offense(<<~RUBY)
+        # TODO(on: date('2019-08-04'))
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{expected_message}
+        def hello
+        end
+      RUBY
+    end
+
     def test_does_not_add_offense_when_todo_is_a_smart_todo
       expect_no_offense(<<~RUBY)
         # TODO(on: date('2019-08-04'), to: 'john@example.com')


### PR DESCRIPTION
Modify the cop if a SmartTodo has no assignee:

- Assigning a user in a SmartTodo is mandatory