### PR TITLE
Add a violation in case a smart todo has a wrong event:

### DIFF
--- a/lib/smart_todo_cop.rb
+++ b/lib/smart_todo_cop.rb
@@ -29,7 +29,9 @@ module RuboCop
         def smart_todo?(comment)
           metadata = ::SmartTodo::Parser::MetadataParser.parse(comment.gsub(/^#/, ''))
 
-          metadata.events.any? && metadata.assignee
+          metadata.events.any? &&
+            metadata.events.all? { |event| event.is_a?(::SmartTodo::Parser::MethodNode) } &&
+            metadata.assignee
         end
       end
     end

--- a/test/smart_todo/smart_todo_cop_test.rb
+++ b/test/smart_todo/smart_todo_cop_test.rb
@@ -25,6 +25,15 @@ module SmartTodo
       RUBY
     end
 
+    def test_add_offense_when_todo_has_an_invalid_event
+      expect_offense(<<~RUBY)
+        # TODO(on: '2019-08-04', to: 'john@example.com')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{expected_message}
+        def hello
+        end
+      RUBY
+    end
+
     def test_add_offense_when_todo_has_an_event_but_no_assignee
       expect_offense(<<~RUBY)
         # TODO(on: date('2019-08-04'))


### PR DESCRIPTION
Add a violation in case a smart todo has a wrong event:

- An event should be a `MethodNode`, i.e. you can't write a Todo like
  `TODO(on: 'dsd', to: 'john@example.com'). In that case the event is
  not a valid one so let's add an offense to warn the user he made a
  mistake