### PR TITLE
Add a `Output` dispatcher

### DIFF
--- a/exe/smart_todo
+++ b/exe/smart_todo
@@ -5,10 +5,8 @@ $LOAD_PATH.unshift("#{__dir__}/../lib")
 
 require 'smart_todo'
 
-unless ENV['ENABLE_SMART_TODO']
-  puts 'Not running SmartTodo since the ENABLE_SMART_TODO ENV is not set'
-
-  exit(0)
+if ENV['ENABLE_SMART_TODO'] && !ARGV.include?('--dispatcher')
+  ARGV << '--dispatcher' << 'slack'
 end
 
 SmartTodo::CLI.new.run

--- a/lib/smart_todo.rb
+++ b/lib/smart_todo.rb
@@ -22,5 +22,6 @@ module SmartTodo
   module Dispatchers
     autoload :Base,                   'smart_todo/dispatchers/base'
     autoload :Slack,                  'smart_todo/dispatchers/slack'
+    autoload :Output,                 'smart_todo/dispatchers/output'
   end
 end

--- a/lib/smart_todo/dispatchers/base.rb
+++ b/lib/smart_todo/dispatchers/base.rb
@@ -12,8 +12,8 @@ module SmartTodo
         case dispatcher
         when "slack"
           Slack
-        when nil
-          Slack
+        when nil, 'output'
+          Output
         end
       end
 

--- a/lib/smart_todo/dispatchers/base.rb
+++ b/lib/smart_todo/dispatchers/base.rb
@@ -59,7 +59,7 @@ module SmartTodo
         header = if user.key?('fallback')
           unexisting_user
         else
-          existing_user(user)
+          existing_user
         end
 
         <<~EOM
@@ -84,8 +84,8 @@ module SmartTodo
       end
 
       # @param user [Hash]
-      def existing_user(user)
-        "Hello #{user.dig('user', 'profile', 'first_name')} :wave:,"
+      def existing_user
+        "Hello :wave:,"
       end
     end
   end

--- a/lib/smart_todo/dispatchers/output.rb
+++ b/lib/smart_todo/dispatchers/output.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SmartTodo
+  module Dispatchers
+    # A simple dispatcher that will output the reminder.
+    class Output < Base
+      def self.validate_options!(_); end
+
+      # @return void
+      def dispatch
+        puts slack_message({})
+      end
+    end
+  end
+end

--- a/lib/smart_todo/dispatchers/slack.rb
+++ b/lib/smart_todo/dispatchers/slack.rb
@@ -41,7 +41,7 @@ module SmartTodo
         if email?
           client.lookup_user_by_email(@assignee)
         else
-          { 'user' => { 'id' => @assignee, 'profile' => { 'first_name' => 'Team' } } }
+          { 'user' => { 'id' => @assignee } }
         end
       end
 

--- a/test/smart_todo/cli_test.rb
+++ b/test/smart_todo/cli_test.rb
@@ -30,7 +30,7 @@ module SmartTodo
 
       generate_ruby_file(ruby_code) do |file|
         Dispatchers::Slack.stub(:new, mock) do
-          cli.run([file.path, '--slack_token', '123', '--fallback_channel', '#general"'])
+          cli.run([file.path, '--slack_token', '123', '--fallback_channel', '#general"', '--dispatcher', 'slack'])
         end
       end
 

--- a/test/smart_todo/dispatchers/slack_test.rb
+++ b/test/smart_todo/dispatchers/slack_test.rb
@@ -21,7 +21,7 @@ module SmartTodo
         assert_requested(:post, /chat.postMessage/) do |request|
           request_body = JSON.parse(request.body)
 
-          assert_match('Hello John', request_body['text'])
+          refute_match("this user or channel doesn't exist on Slack anymore", request_body['text'])
           assert_equal('ABC', request_body['channel'])
         end
       end
@@ -81,7 +81,7 @@ module SmartTodo
         assert_requested(:post, /chat.postMessage/) do |request|
           request_body = JSON.parse(request.body)
 
-          assert_match('Hello Team', request_body['text'])
+          refute_match("this user or channel doesn't exist on Slack anymore", request_body['text'])
           assert_equal('#my_channel', request_body['channel'])
         end
       end

--- a/test/smart_todo/integration_test.rb
+++ b/test/smart_todo/integration_test.rb
@@ -17,7 +17,7 @@ module SmartTodo
       end
 
       assert_slack_message_sent(
-        'Hello John',
+        'Hello :wave:,',
         'We are past the *2015-03-01* due date'
       )
     end
@@ -38,7 +38,7 @@ module SmartTodo
       end
 
       assert_slack_message_sent(
-        'Hello John',
+        'Hello :wave:,',
         'The gem *rails* was released to version *5.1.1*'
       )
     end
@@ -59,7 +59,7 @@ module SmartTodo
       end
 
       assert_slack_message_sent(
-        'Hello John',
+        'Hello :wave:,',
         "The Pull Request or Issue https://github.com/shopify/shopify/pull/123\nis now closed"
       )
     end
@@ -80,7 +80,7 @@ module SmartTodo
       end
 
       assert_slack_message_sent(
-        'Hello John',
+        'Hello :wave:,',
         "The Pull Request or Issue https://github.com/shopify/shopify/pull/123\nis now closed"
       )
     end

--- a/test/smart_todo/integration_test.rb
+++ b/test/smart_todo/integration_test.rb
@@ -108,7 +108,7 @@ module SmartTodo
     def run_cli(file)
       stub_slack_request
 
-      CLI.new.run([file.path, '--slack_token', '123', '--fallback_channel', '#general"'])
+      CLI.new.run([file.path, '--slack_token', '123', '--fallback_channel', '#general"', '--dispatcher', 'slack'])
     end
   end
 end


### PR DESCRIPTION
Add a `Output` dispatcher:

- This dispatcher is gonna be the default one and will just output
  the expired todo. This is useful for debugging purposes as well
  as to get rid the `ENABLE_SMART_TODO` environment variable.

  Added a new `--dispatcher` option to the CLI, which for now accepts
  either `slack` or `output`.
  For backward compatibility reasons, the `--dispatcher slack` will be
  added automatically in case the `ENABLE_SMART_TODO` env is present,
  but I plan to remove that in the future. Users will have to manually
  tell through which dispatcher they want their message to be sent.

  Fix #32