### PR TITLE
Fix crash on bad syntax for `TODO(on:)`

### DIFF
--- a/lib/smart_todo/parser/metadata_parser.rb
+++ b/lib/smart_todo/parser/metadata_parser.rb
@@ -103,6 +103,8 @@ module SmartTodo
       # @param method_node [MethodNode]
       # @return [void]
       def on_todo_event(method_node)
+        return unless method_node.is_a?(MethodNode)
+
         events << method_node
       end
 

--- a/test/smart_todo/cli_test.rb
+++ b/test/smart_todo/cli_test.rb
@@ -78,5 +78,20 @@ module SmartTodo
     ensure
       Encoding.default_external = previous_encoding
     end
+
+    def test_does_not_crash_if_the_event_is_incorrectly_formated
+      cli = CLI.new
+      ruby_code = <<~EOM
+        # TODO(on: '2010-03-02', to: '#general')
+        def hello
+        end
+      EOM
+
+      generate_ruby_file(ruby_code) do |file|
+        cli.run([file.path, '--slack_token', '123', '--fallback_channel', '#general"'])
+      end
+
+      assert_not_requested(:post, /chat.postMessage/)
+    end
   end
 end

--- a/test/smart_todo/parser/metadata_parser_test.rb
+++ b/test/smart_todo/parser/metadata_parser_test.rb
@@ -59,6 +59,16 @@ module SmartTodo
         assert_nil(result.assignee)
       end
 
+      def test_parse_when_todo_metadata_on_is_uncorrectly_formatted
+        ruby_code = <<~RUBY
+          TODO(on: '2019-08-04')
+        RUBY
+
+        result = MetadataParser.parse(ruby_code)
+        assert_empty(result.events)
+        assert_nil(result.assignee)
+      end
+
       def test_when_a_smart_todo_has_incorrect_ruby_syntax
         ruby_code = <<~EOM
           # TODO(A<<+<<)


### PR DESCRIPTION
Before this PR, using an incorrectly formatted TODO like `TODO(on: '2019-09-10')` would result in an application crash:

```
NoMethodError: undefined method `method_name' for "2019-09-10":String
Did you mean?  method
```

See commits 4aed306 and 171632a for detailed tests.

This PR fixes this crash by ignoring TODOs with a badly formatted `on` meta-data.