### PR TITLE
Add a GemBump event, matching your installed dependencies

### DIFF
--- a/lib/smart_todo.rb
+++ b/lib/smart_todo.rb
@@ -15,6 +15,7 @@ module SmartTodo
 
   module Events
     autoload :Date,                   'smart_todo/events/date'
+    autoload :GemBump,                'smart_todo/events/gem_bump'
     autoload :GemRelease,             'smart_todo/events/gem_release'
     autoload :IssueClose,             'smart_todo/events/issue_close'
   end

--- a/lib/smart_todo/events.rb
+++ b/lib/smart_todo/events.rb
@@ -38,6 +38,15 @@ module SmartTodo
       GemRelease.new(gem_name, requirements).met?
     end
 
+    # Check if +gem_name+ was bumped to the +requirements+ expected
+    #
+    # @param gem_name [String]
+    # @param requirements [Array<String>] a list of version specifiers
+    # @return [false, String]
+    def gem_bump(gem_name, *requirements)
+      GemBump.new(gem_name, requirements).met?
+    end
+
     # Check if the issue +issue_number+ is closed
     #
     # @param organization [String] the GitHub organization name

--- a/lib/smart_todo/events/gem_bump.rb
+++ b/lib/smart_todo/events/gem_bump.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+gem('bundler')
+require 'bundler'
+
+module SmartTodo
+  module Events
+    # An event that compare the version of a gem specified in your Gemfile.lock
+    # with the expected version specifiers.
+    class GemBump
+      # @param gem_name [String]
+      # @param requirements [Array] a list of version specifiers.
+      #   The specifiers are the same as the one used in Gemfiles or Gemspecs
+      #
+      # @example Expecting a specific version
+      #   GemBump.new('rails', ['6.0'])
+      #
+      # @example Expecting a version in the 5.x.x series
+      #   GemBump.new('rails', ['> 5.2', '< 6'])
+      def initialize(gem_name, requirements)
+        @gem_name = gem_name
+        @requirements = Gem::Requirement.new(requirements)
+      end
+
+      # @return [String, false]
+      def met?
+        return error_message if spec_set[@gem_name].empty?
+
+        installed_version = spec_set[@gem_name].first.version
+        if @requirements.satisfied_by?(installed_version)
+          message(installed_version)
+        else
+          false
+        end
+      end
+
+      # Error message send to Slack in case a gem couldn't be found
+      #
+      # @return [String]
+      def error_message
+        "The gem *#{@gem_name}* is not in your dependencies, I can't determine if your TODO is ready to be addressed."
+      end
+
+      # @return [String]
+      def message(version_number)
+        "The gem *#{@gem_name}* was updated to version *#{version_number}* and your TODO is now ready to be addressed."
+      end
+
+      private
+
+      # @return [Bundler::SpecSet] an instance of Bundler::SpecSet
+      def spec_set
+        @spec_set ||= Bundler.load.specs
+      end
+    end
+  end
+end

--- a/test/smart_todo/events/gem_bump_test.rb
+++ b/test/smart_todo/events/gem_bump_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'bundler'
+
+module SmartTodo
+  module Events
+    class GemBumpTest < Minitest::Test
+      def test_when_gem_is_released
+        bump = GemBump.new('rubocop', '0.71')
+        expected = 'The gem *rubocop* was updated to version *0.71.0* and your TODO is now ready to be addressed.'
+
+        bump.stub(:spec_set, fake_bundler_specs) do
+          assert_equal(expected, bump.met?)
+        end
+      end
+
+      def test_with_pessimistic_constraint
+        bump = GemBump.new('rubocop', '~>0.50')
+        expected = 'The gem *rubocop* was updated to version *0.71.0* and your TODO is now ready to be addressed.'
+
+        bump.stub(:spec_set, fake_bundler_specs) do
+          assert_equal(expected, bump.met?)
+        end
+      end
+
+      def test_with_multiple_constraints
+        bump = GemBump.new('rubocop', ['> 0.50', '< 1'])
+        expected = 'The gem *rubocop* was updated to version *0.71.0* and your TODO is now ready to be addressed.'
+
+        bump.stub(:spec_set, fake_bundler_specs) do
+          assert_equal(expected, bump.met?)
+        end
+      end
+
+      def test_when_gem_is_not_yet_released
+        bump = GemBump.new('rubocop', '1')
+
+        bump.stub(:spec_set, fake_bundler_specs) do
+          assert_equal(false, bump.met?)
+        end
+      end
+
+      def test_when_gem_does_not_exist
+        bump = GemBump.new('beep_boop', '1')
+        expected =
+          "The gem *beep_boop* is not in your dependencies, I can't determine if your TODO is ready to be addressed."
+
+        bump.stub(:spec_set, fake_bundler_specs) do
+          assert_equal(expected, bump.met?)
+        end
+      end
+
+      def fake_bundler_specs
+        @fake_bundler_specs ||= Bundler::SpecSet.new(
+          Bundler::LockfileParser.new(Bundler.read_file('test/smart_todo/fixtures/Gemfile.lock')).specs
+        )
+      end
+    end
+  end
+end

--- a/test/smart_todo/fixtures/Gemfile.lock
+++ b/test/smart_todo/fixtures/Gemfile.lock
@@ -1,0 +1,50 @@
+PATH
+  remote: .
+  specs:
+    smart_todo (1.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    ast (2.4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    hashdiff (0.4.0)
+    jaro_winkler (1.5.3)
+    minitest (5.11.3)
+    parallel (1.17.0)
+    parser (2.6.3.0)
+      ast (~> 2.4.0)
+    public_suffix (3.1.1)
+    rainbow (3.0.0)
+    rake (10.5.0)
+    rubocop (0.71.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
+    safe_yaml (1.0.5)
+    unicode-display_width (1.6.0)
+    webmock (3.6.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.17)
+  minitest (~> 5.0)
+  rake (~> 10.0)
+  rubocop (~> 0.71)
+  smart_todo!
+  webmock
+
+BUNDLED WITH
+   1.17.3


### PR DESCRIPTION
Hey! 👋 

This gem is really awesome! I decided to add the `gem_bump` event, which is one of our main use-case for todos. The event will be triggered if the installed version of a gem match the passed requirements, pretty much like the `gem_release` event.
ex:
```
# TODO(on: gem_bumb('rails', '~> 6.1'), to: '...')
```
I used bundler programatically, it seemed the most logical tool to handle the situation, but I had a hard time setting up tests that wouldn't use the bundler specs of the gem itself.  I'm also my first time writing tests with  Minitest, let me know if there's a better solution than what I did for the tests.

Fix #7 