### PR TITLE
Remove wrong doc tag param for `existing_user`

### DIFF
--- a/lib/smart_todo/dispatchers/base.rb
+++ b/lib/smart_todo/dispatchers/base.rb
@@ -83,7 +83,7 @@ module SmartTodo
         "Hello :wave:,\n\n`#{@assignee}` had an assigned TODO but this user or channel doesn't exist on Slack anymore."
       end
 
-      # @param user [Hash]
+      # Hello message for user actually existing in the organization
       def existing_user
         "Hello :wave:,"
       end


### PR DESCRIPTION
`existing_user` doesn't seem to accept a `user` param anymore.

Signed-off-by: Alexandre Terrasa <alexandre.terrasa@shopify.com>