### PR TITLE
Allow multiple assignees in a same SmartTodo

### DIFF
--- a/lib/smart_todo/dispatchers/base.rb
+++ b/lib/smart_todo/dispatchers/base.rb
@@ -38,7 +38,7 @@ module SmartTodo
         @todo_node = todo_node
         @options = options
         @file = file
-        @assignee = @todo_node.metadata.assignee
+        @assignees = @todo_node.metadata.assignees
       end
 
       # This method gets called when a TODO reminder is expired and needs to be delivered.
@@ -54,10 +54,11 @@ module SmartTodo
       # Prepare the content of the message to send to the TODO assignee
       #
       # @param user [Hash] contain information about a user
+      # @param assignee [String] original string handle the slack message should be sent
       # @return [String]
-      def slack_message(user)
+      def slack_message(user, assignee)
         header = if user.key?('fallback')
-          unexisting_user
+          unexisting_user(assignee)
         else
           existing_user
         end
@@ -78,9 +79,10 @@ module SmartTodo
 
       # Message in case a TODO's assignee doesn't exist in the Slack organization
       #
+      # @param user [Hash]
       # @return [String]
-      def unexisting_user
-        "Hello :wave:,\n\n`#{@assignee}` had an assigned TODO but this user or channel doesn't exist on Slack anymore."
+      def unexisting_user(assignee)
+        "Hello :wave:,\n\n`#{assignee}` had an assigned TODO but this user or channel doesn't exist on Slack anymore."
       end
 
       # Hello message for user actually existing in the organization

--- a/lib/smart_todo/parser/metadata_parser.rb
+++ b/lib/smart_todo/parser/metadata_parser.rb
@@ -78,10 +78,11 @@ module SmartTodo
     end
 
     class Visitor
-      attr_reader :events, :assignee
+      attr_reader :events, :assignees
 
       def initialize
         @events = []
+        @assignees = []
       end
 
       # Iterate over each tokens returned from the parser and call
@@ -111,7 +112,7 @@ module SmartTodo
       # @param assignee [String]
       # @return [void]
       def on_todo_assignee(assignee)
-        @assignee = assignee
+        @assignees << assignee
       end
     end
   end

--- a/lib/smart_todo_cop.rb
+++ b/lib/smart_todo_cop.rb
@@ -31,7 +31,7 @@ module RuboCop
 
           metadata.events.any? &&
             metadata.events.all? { |event| event.is_a?(::SmartTodo::Parser::MethodNode) } &&
-            metadata.assignee
+            metadata.assignees.any?
         end
       end
     end

--- a/test/smart_todo/parser/comment_parser_test.rb
+++ b/test/smart_todo/parser/comment_parser_test.rb
@@ -151,7 +151,7 @@ module SmartTodo
 
         todo = CommentParser.new(ruby_code).parse
         assert_equal('date', todo[0].metadata.events[0].method_name)
-        assert_equal('john@example.com', todo[0].metadata.assignee)
+        assert_equal(['john@example.com'], todo[0].metadata.assignees)
       end
     end
   end

--- a/test/smart_todo/parser/metadata_parser_test.rb
+++ b/test/smart_todo/parser/metadata_parser_test.rb
@@ -13,7 +13,7 @@ module SmartTodo
         result = MetadataParser.parse(ruby_code)
         assert_equal(1, result.events.size)
         assert_equal('date', result.events[0].method_name)
-        assert_equal('john@example.com', result.assignee)
+        assert_equal(['john@example.com'], result.assignees)
       end
 
       def test_parse_todo_metadata_with_multiple_event
@@ -25,7 +25,7 @@ module SmartTodo
         assert_equal(2, result.events.size)
         assert_equal('date', result.events[0].method_name)
         assert_equal('gem_release', result.events[1].method_name)
-        assert_equal('john@example.com', result.assignee)
+        assert_equal(['john@example.com'], result.assignees)
       end
 
       def test_parse_todo_metadata_with_no_assignee
@@ -35,7 +35,29 @@ module SmartTodo
 
         result = MetadataParser.parse(ruby_code)
         assert_equal('date', result.events[0].method_name)
-        assert_nil(result.assignee)
+        assert_empty(result.assignees)
+      end
+
+      def test_parse_todo_metadata_with_multiple_assignees
+        ruby_code = <<~RUBY
+          TODO(on: something('abc', '123', '456'), to: 'john@example.com', to: 'janne@example.com')
+        RUBY
+
+        result = MetadataParser.parse(ruby_code)
+        assert_equal('something', result.events[0].method_name)
+        assert_equal(['abc', '123', '456'], result.events[0].arguments)
+        assert_equal(['john@example.com', 'janne@example.com'], result.assignees)
+      end
+
+      def test_parse_todo_metadata_with_repeated_assignees
+        ruby_code = <<~RUBY
+          TODO(on: something('abc', '123', '456'), to: 'john@example.com', to: 'john@example.com')
+        RUBY
+
+        result = MetadataParser.parse(ruby_code)
+        assert_equal('something', result.events[0].method_name)
+        assert_equal(['abc', '123', '456'], result.events[0].arguments)
+        assert_equal(['john@example.com', 'john@example.com'], result.assignees)
       end
 
       def test_parse_todo_metadata_with_multiple_arguments
@@ -46,7 +68,7 @@ module SmartTodo
         result = MetadataParser.parse(ruby_code)
         assert_equal('something', result.events[0].method_name)
         assert_equal(['abc', '123', '456'], result.events[0].arguments)
-        assert_equal('john@example.com', result.assignee)
+        assert_equal(['john@example.com'], result.assignees)
       end
 
       def test_parse_when_todo_metadata_is_uncorrectly_formatted
@@ -56,7 +78,7 @@ module SmartTodo
 
         result = MetadataParser.parse(ruby_code)
         assert_empty(result.events)
-        assert_nil(result.assignee)
+        assert_empty(result.assignees)
       end
 
       def test_parse_when_todo_metadata_on_is_uncorrectly_formatted
@@ -66,7 +88,7 @@ module SmartTodo
 
         result = MetadataParser.parse(ruby_code)
         assert_empty(result.events)
-        assert_nil(result.assignee)
+        assert_empty(result.assignees)
       end
 
       def test_when_a_smart_todo_has_incorrect_ruby_syntax
@@ -79,7 +101,7 @@ module SmartTodo
 
         result = MetadataParser.parse(ruby_code)
         assert_empty(result.events)
-        assert_nil(result.assignee)
+        assert_empty(result.assignees)
       end
 
       def test_parse_when_todo_metadata_is_not_ruby_code
@@ -89,7 +111,7 @@ module SmartTodo
 
         result = MetadataParser.parse(ruby_code)
         assert_empty(result.events)
-        assert_nil(result.assignee)
+        assert_empty(result.assignees)
       end
     end
   end


### PR DESCRIPTION
This PR allows people to specify more than one `to:` parameter by SmartTodo.

This can be useful when you want multiple channels/users to be pinged on events or if you fear the channel/user will not be existing and you want another backup than the `fallback` option.

---

For example, the following TODO:

```ruby
# TODO(on: X, to: '@Alex', to: '#us')
```

Will send two slack notifications, one to the user `@Alex` and one to the channel `#us`.

---

Changes:
1. First commit changes the TODOs parsing so it can allocate more than one assignee in the TODO metadata.
2. Second commit changes the Slack dispatcher so each assignee in a TODO gets a request.