### PR TITLE
fix ArgumentError in Output dispatcher

### DIFF
--- a/lib/smart_todo/dispatchers/output.rb
+++ b/lib/smart_todo/dispatchers/output.rb
@@ -8,7 +8,7 @@ module SmartTodo
 
       # @return void
       def dispatch
-        puts slack_message({})
+        puts slack_message({}, nil)
       end
     end
   end

--- a/test/smart_todo/dispatchers/output_test.rb
+++ b/test/smart_todo/dispatchers/output_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module SmartTodo
+  module Dispatchers
+    class OutputTest < Minitest::Test
+      def test_dispatch_prints_the_expected_message
+        dispatcher = Output.new("Foo", todo_node, "file.rb", {})
+        assert_output(/Hello \:wave\:\,/) do
+          dispatcher.dispatch
+        end
+      end
+
+      private
+
+      def todo_node
+        ruby_code = <<~EOM
+          # TODO(on: date('2011-03-02'), to: 'john@example.com'")
+          def hello
+          end
+        EOM
+
+        Parser::CommentParser.new(ruby_code).parse[0]
+      end
+    end
+  end
+end


### PR DESCRIPTION
I'm [seeing](https://buildkite.com/shopify/banking/builds/19404#f94db21c-39fa-4351-a23c-f0dc1a26a3bb) the following in our repo:

```ruby
/tmp/bundle/ruby/3.0.0/gems/smart_todo-1.3.0/lib/smart_todo/dispatchers/base.rb:59:in `slack_message': wrong number of arguments (given 1, expected 2) (ArgumentError)
from /tmp/bundle/ruby/3.0.0/gems/smart_todo-1.3.0/lib/smart_todo/dispatchers/output.rb:11:in `dispatch'
```

The `OutputDispatcher` is trying to call its inherited method `slack_message` with one argument, when it actually takes two. The second argument is `assignee` which is only used if the first argument (`user`) has the key `fallback`, so it can be `nil`. This also adds a simple test.