### PR TITLE
Fix ArgumentError in output dispatcher

### DIFF
--- a/lib/smart_todo/dispatchers/output.rb
+++ b/lib/smart_todo/dispatchers/output.rb
@@ -8,7 +8,7 @@ module SmartTodo
 
       # @return void
       def dispatch
-        puts slack_message({})
+        puts slack_message({}, nil)
       end
     end
   end

--- a/test/smart_todo/dispatchers/output_test.rb
+++ b/test/smart_todo/dispatchers/output_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module SmartTodo
+  module Dispatchers
+    class OutputTest < Minitest::Test
+      def setup
+        @options = { fallback_channel: "#general", slack_token: "123" }
+      end
+
+      def test_dispatch
+        dispatcher = Output.new("Foo", todo_node, "file.rb", @options)
+        expected_text = <<~HEREDOC
+          Hello :wave:,
+
+          You have an assigned TODO in the `file.rb` file.
+          Foo
+
+          Here is the associated comment on your TODO:
+
+          ```
+
+          ```
+        HEREDOC
+
+        assert_output(expected_text) { dispatcher.dispatch }
+      end
+
+      private
+
+      def todo_node(*assignees)
+        tos = assignees.map { |assignee| "to: '#{assignee}'" }
+        tos << "to: 'john@example.com'" if assignees.empty?
+
+        ruby_code = <<~EOM
+          # TODO(on: date('2011-03-02'), #{tos.join(", ")})
+          def hello
+          end
+        EOM
+
+        Parser::CommentParser.new(ruby_code).parse[0]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Version 1.3.0 of this gem introduced a bug in the `Output` dispatcher that outputs the smart todo to stdout.

This PR fixes the `ArgumentError` and adds a test for the class.