### PR TITLE
Change master -> main for GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
The default branch for this repo was changed from master to main.

This PR just fixes the GitHub Actions CI config so it works on the new branch name.