### PR TITLE
Prevent crash when malformed emails are present

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -4,8 +4,12 @@ type:
   - ruby
 
 up:
-  - ruby: 2.7.4
+  - ruby: 3.0.2
   - bundler
+
+console:
+  desc: 'start a console'
+  run: bin/console
 
 test:
   bundle exec rake test

--- a/lib/smart_todo/slack_client.rb
+++ b/lib/smart_todo/slack_client.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cgi"
 require "net/http"
 require "json"
 
@@ -37,14 +38,14 @@ module SmartTodo
     # @param email [String]
     # @return [Hash]
     #
-    # @raise [Net::HTTPError] in case the reques to Slack failed
-    # @raise [SlackClient::Error] in case Slack returs a { ok: false } in the body
+    # @raise [Net::HTTPError] in case the request to Slack failed
+    # @raise [SlackClient::Error] in case Slack returns a { ok: false } in the body
     #
     # @see https://api.slack.com/methods/users.lookupByEmail
     def lookup_user_by_email(email)
       headers = { "Content-Type" => "application/x-www-form-urlencoded" }
 
-      request(:get, "/api/users.lookupByEmail?email=#{email}", nil, headers)
+      request(:get, "/api/users.lookupByEmail?email=#{CGI.escape(email)}", nil, headers)
     end
 
     # Send a message to a Slack channel or to a user
@@ -53,8 +54,8 @@ module SmartTodo
     # @param text [String] The message to send
     # @return [Hash]
     #
-    # @raise [Net::HTTPError] in case the reques to Slack failed
-    # @raise [SlackClient::Error] in case Slack returs a { ok: false } in the body
+    # @raise [Net::HTTPError] in case the request to Slack failed
+    # @raise [SlackClient::Error] in case Slack returns a { ok: false } in the body
     #
     # @see https://api.slack.com/methods/chat.postMessage
     def post_message(channel, text)
@@ -68,8 +69,8 @@ module SmartTodo
     # @param data [String] JSON encoded data when making a POST request
     # @param headers [Hash]
     #
-    # @raise [Net::HTTPError] in case the reques to Slack failed
-    # @raise [SlackClient::Error] in case Slack returs a { ok: false } in the body
+    # @raise [Net::HTTPError] in case the request to Slack failed
+    # @raise [SlackClient::Error] in case Slack returns a { ok: false } in the body
     def request(method, endpoint, data = nil, headers = {})
       response = case method
       when :post, :patch
@@ -87,8 +88,8 @@ module SmartTodo
     #   (Net::HTTPOK, Net::HTTPNotFound ...)
     # @return [Hash]
     #
-    # @raise [Net::HTTPError] in case the reques to Slack failed
-    # @raise [SlackClient::Error] in case Slack returs a { ok: false } in the body
+    # @raise [Net::HTTPError] in case the request to Slack failed
+    # @raise [SlackClient::Error] in case Slack returns a { ok: false } in the body
     def slack_response!(response)
       raise(Net::HTTPError.new("Request to slack failed", response)) unless response.code_type < Net::HTTPSuccess
       body = JSON.parse(response.body)

--- a/test/smart_todo/slack_client_test.rb
+++ b/test/smart_todo/slack_client_test.rb
@@ -22,7 +22,7 @@ module SmartTodo
       end
     end
 
-    def test_lookup_user_by_email_when_user_does_not_exists
+    def test_lookup_user_by_email_when_user_does_not_exist
       stub_request(:get, /slack.com/)
         .to_return(body: JSON.dump(ok: false, error: "users_not_found"))
 


### PR DESCRIPTION
We had an issue recently where a developer had added an invalid `to` clause to a smart todo comment that looked something like:

```ruby
# TODO(on: date('2021-11-30'), to: 'andrew.kerr@shopify.com, somebody.else@shopify.com')
```

With a comment configured like this, the gem attempts to do `lookupByEmail` API call to Slack, which fails with a 400 error, which then causes the gem to raise and crash the smart_todo run.

This PR simply encodes the `to` parameters properly so that the API call is valid. It now will correctly return a user not found response from Slack, which triggers the flow that posts the comment to the fallback channel, if present.
