### PR TITLE
Introduce multiple GitHub token support

### DIFF
--- a/test/smart_todo/events/issue_close_test.rb
+++ b/test/smart_todo/events/issue_close_test.rb
@@ -50,18 +50,16 @@ module SmartTodo
       end
 
       def test_when_token_env_is_present
-        ENV[IssueClose::TOKEN_ENV] = "abc"
+        with_env(IssueClose::TOKEN_ENV => "abc") do
+          stub_request(:get, /api.github.com/)
+            .to_return(body: JSON.dump(state: "open"))
 
-        stub_request(:get, /api.github.com/)
-          .to_return(body: JSON.dump(state: "open"))
+          assert_equal(false, IssueClose.new("rails", "rails", "123", type: "pulls").met?)
 
-        assert_equal(false, IssueClose.new("rails", "rails", "123", type: "pulls").met?)
-
-        assert_requested(:get, /api.github.com/) do |request|
-          assert(request.headers.key?("Authorization"))
+          assert_requested(:get, /api.github.com/) do |request|
+            assert_equal("token abc", request.headers["Authorization"])
+          end
         end
-      ensure
-        ENV.delete(IssueClose::TOKEN_ENV)
       end
 
       def test_calls_the_right_endpoint_when_type_is_pull_request
@@ -80,6 +78,16 @@ module SmartTodo
 
         assert_equal(false, IssueClose.new("rails", "rails", "123", type: "issues").met?)
         assert_requested(:get, expected_endpoint)
+      end
+
+      private
+
+      def with_env(env = {})
+        original_env = ENV.to_h
+        ENV.merge!(env)
+        yield
+      ensure
+        ENV.replace(original_env)
       end
     end
   end


### PR DESCRIPTION
This enable multiple GitHub token support.

It starts by looking at whether there is a repo-specific token, then fall backs to more generic ones:
- `SMART_TODO_GITHUB_TOKEN__<ORG>__<REPO>`
- `SMART_TODO_GITHUB_TOKEN__<ORG>`
- `SMART_TODO_GITHUB_TOKEN` (Default)

The `<ORG>` and `<REPO>` parts should be uppercased and use underscores.
For example, `Shopify/my-repo` would become `SMART_TODO_GITHUB_TOKEN__SHOPIFY__MY_REPO=...`.

This is particularly helpful when needing to access multiple private orgs, each having their own private GitHub app