### PR TITLE
Implement HTTP timeout/retry policies for GitHub/RubyGems/Slack clients

### DIFF
--- a/lib/smart_todo.rb
+++ b/lib/smart_todo.rb
@@ -9,6 +9,7 @@ module SmartTodo
   autoload :CLI,                      "smart_todo/cli"
   autoload :Todo,                     "smart_todo/todo"
   autoload :CommentParser,            "smart_todo/comment_parser"
+  autoload :HttpClientBuilder,        "smart_todo/http_client_builder"
 
   module Dispatchers
     autoload :Base,                   "smart_todo/dispatchers/base"

--- a/lib/smart_todo/events.rb
+++ b/lib/smart_todo/events.rb
@@ -184,12 +184,18 @@ module SmartTodo
     def rubygems_client
       @rubygems_client ||= Net::HTTP.new("rubygems.org", Net::HTTP.https_default_port).tap do |client|
         client.use_ssl = true
+        client.read_timeout = 30
+        client.ssl_timeout = 15
+        client.max_retries = 2
       end
     end
 
     def github_client
       @github_client ||= Net::HTTP.new("api.github.com", Net::HTTP.https_default_port).tap do |client|
         client.use_ssl = true
+        client.read_timeout = 30
+        client.ssl_timeout = 15
+        client.max_retries = 2
       end
     end
 

--- a/lib/smart_todo/events.rb
+++ b/lib/smart_todo/events.rb
@@ -182,21 +182,11 @@ module SmartTodo
     end
 
     def rubygems_client
-      @rubygems_client ||= Net::HTTP.new("rubygems.org", Net::HTTP.https_default_port).tap do |client|
-        client.use_ssl = true
-        client.read_timeout = 30
-        client.ssl_timeout = 15
-        client.max_retries = 2
-      end
+      @rubygems_client ||= HttpClientBuilder.build("rubygems.org")
     end
 
     def github_client
-      @github_client ||= Net::HTTP.new("api.github.com", Net::HTTP.https_default_port).tap do |client|
-        client.use_ssl = true
-        client.read_timeout = 30
-        client.ssl_timeout = 15
-        client.max_retries = 2
-      end
+      @github_client ||= HttpClientBuilder.build("api.github.com")
     end
 
     def github_headers(organization, repo)

--- a/lib/smart_todo/http_client_builder.rb
+++ b/lib/smart_todo/http_client_builder.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+module SmartTodo
+  # @api private
+  class HttpClientBuilder
+    class << self
+      def build(endpoint)
+        Net::HTTP.new(endpoint, Net::HTTP.https_default_port).tap do |client|
+          client.use_ssl = true
+          client.read_timeout = 30
+          client.ssl_timeout = 15
+          client.max_retries = 2
+        end
+      end
+    end
+  end
+end

--- a/lib/smart_todo/slack_client.rb
+++ b/lib/smart_todo/slack_client.rb
@@ -30,6 +30,7 @@ module SmartTodo
         client.use_ssl = true
         client.read_timeout = 30
         client.ssl_timeout = 15
+        client.max_retries = 2
       end
     end
 

--- a/lib/smart_todo/slack_client.rb
+++ b/lib/smart_todo/slack_client.rb
@@ -26,12 +26,7 @@ module SmartTodo
     # @param slack_token [String]
     def initialize(slack_token)
       @slack_token = slack_token
-      @client = Net::HTTP.new("slack.com", Net::HTTP.https_default_port).tap do |client|
-        client.use_ssl = true
-        client.read_timeout = 30
-        client.ssl_timeout = 15
-        client.max_retries = 2
-      end
+      @client = HttpClientBuilder.build("slack.com")
     end
 
     # Retrieve the Slack ID of a user from his email

--- a/test/smart_todo/http_client_builder_test.rb
+++ b/test/smart_todo/http_client_builder_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tempfile"
+
+module SmartTodo
+  class HttpBuilderTest < Minitest::Test
+    def test_builds_http_client_with_proper_config
+      client = HttpClientBuilder.build("example.com")
+
+      assert_equal("example.com", client.address)
+      assert_equal(15, client.ssl_timeout)
+      assert_equal(30, client.read_timeout)
+      assert_equal(2, client.max_retries)
+    end
+  end
+end


### PR DESCRIPTION
Just making sure that a single timeout will not invalidate the whole step in CI.

If timeouts keep happening, chances are the service is unavailable, so erroring is fine, but if a timeout is a fluke, we should at least retry.
As all HTTP clients in this gem were using the same settings, @gmcgibbon and I factorized the logic in a `HttpClientBuilder` which we can also test.

(WebMock takes `Net::HTTP` completely out of the equation so it cannot test, for example `max_retries` values.)

<!-- closes https://github.com/Shopify/rails-infra/issues/605 -->