### PR TITLE
Remove Prism gem verison lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     smart_todo (1.7.0)
-      prism (~> 0.15)
+      prism
 
 GEM
   remote: https://rubygems.org/

--- a/smart_todo.gemspec
+++ b/smart_todo.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ["smart_todo"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency("prism", "~> 0.15")
+  spec.add_runtime_dependency("prism")
   spec.add_development_dependency("bundler", ">= 1.17")
   spec.add_development_dependency("minitest", "~> 5.0")
   spec.add_development_dependency("rake", ">= 10.0")


### PR DESCRIPTION
This remove the Prism version lock (fix #78).

If we really want to test older version we could use a build matrix and multiple Gemfiles but I am not sure this is worth it for this project scope? Are older versions of prism support critical for some reason?