### PR TITLE
Updates for rubocop deprecations

### DIFF
--- a/lib/smart_todo_cop.rb
+++ b/lib/smart_todo_cop.rb
@@ -9,7 +9,7 @@ module RuboCop
       # This Cop does not run by default. It should be added to the RuboCop host's configuration file.
       #
       # @see https://rubocop.readthedocs.io/en/latest/extensions/#loading-extensions
-      class SmartTodoCop < Cop
+      class SmartTodoCop < Base
         HELP = "For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax"
         MSG = "Don't write regular TODO comments. Write SmartTodo compatible syntax comments. #{HELP}"
 

--- a/lib/smart_todo_cop.rb
+++ b/lib/smart_todo_cop.rb
@@ -15,7 +15,7 @@ module RuboCop
 
         # @param processed_source [RuboCop::ProcessedSource]
         # @return [void]
-        def investigate(processed_source)
+        def on_new_investigation
           processed_source.comments.each do |comment|
             next unless /^#\sTODO/.match?(comment.text)
 

--- a/test/smart_todo/smart_todo_cop_test.rb
+++ b/test/smart_todo/smart_todo_cop_test.rb
@@ -84,19 +84,19 @@ module SmartTodo
 
     def expect_offense(source)
       annotated_source = RuboCop::RSpec::ExpectOffense::AnnotatedSource.parse(source)
-      investigate(annotated_source.plain_source)
+      report = investigate(annotated_source.plain_source)
 
-      actual_annotations = annotated_source.with_offense_annotations(cop.offenses)
-      assert_equal(actual_annotations.to_s, annotated_source.to_s)
+      actual_annotations = annotated_source.with_offense_annotations(report.offenses)
+      assert_equal(annotated_source.to_s, actual_annotations.to_s)
     end
     alias_method :expect_no_offense, :expect_offense
 
     def investigate(source, ruby_version = 2.5, file = "(file)")
       processed_source = RuboCop::ProcessedSource.new(source, ruby_version, file)
 
-      RuboCop::Cop::Commissioner.new([cop], [], raise_error: true).tap do |commissioner|
-        commissioner.investigate(processed_source)
-      end
+      assert(processed_source.valid_syntax?)
+      comm = RuboCop::Cop::Commissioner.new([cop], [], raise_error: true)
+      comm.investigate(processed_source)
     end
 
     def cop


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/v1_upgrade_notes.html

This is causing warnings in rubocop runs in repositories that use this gem.