### PR TITLE
Optionally include repository name in notifications

### DIFF
--- a/lib/smart_todo/cli.rb
+++ b/lib/smart_todo/cli.rb
@@ -66,6 +66,9 @@ module SmartTodo
         opts.on("--dispatcher DISPATCHER") do |dispatcher|
           @options[:dispatcher] = dispatcher
         end
+        opts.on("--repo [REPO]", "Repository name to include in notifications") do |repo|
+          @options[:repo] = repo || File.basename(Dir.pwd)
+        end
       end
     end
 

--- a/lib/smart_todo/dispatchers/base.rb
+++ b/lib/smart_todo/dispatchers/base.rb
@@ -68,7 +68,7 @@ module SmartTodo
         <<~EOM
           #{header}
 
-          You have an assigned TODO in the `#{@file}` file.
+          You have an assigned TODO in the `#{@file}` file#{repo}.
           #{@event_message}
 
           Here is the associated comment on your TODO:
@@ -90,6 +90,15 @@ module SmartTodo
       # Hello message for user actually existing in the organization
       def existing_user
         "Hello :wave:,"
+      end
+
+      def repo
+        repo = @options[:repo]
+        return unless repo
+
+        unless repo.empty?
+          " in repository `#{repo}`"
+        end
       end
     end
   end

--- a/test/smart_todo/dispatchers/output_test.rb
+++ b/test/smart_todo/dispatchers/output_test.rb
@@ -6,7 +6,7 @@ module SmartTodo
   module Dispatchers
     class OutputTest < Minitest::Test
       def setup
-        @options = { fallback_channel: "#general", slack_token: "123" }
+        @options = { fallback_channel: "#general", slack_token: "123", repo: "example" }
       end
 
       def test_dispatch
@@ -14,7 +14,7 @@ module SmartTodo
         expected_text = <<~HEREDOC
           Hello :wave:,
 
-          You have an assigned TODO in the `file.rb` file.
+          You have an assigned TODO in the `file.rb` file in repository `example`.
           Foo
 
           Here is the associated comment on your TODO:


### PR DESCRIPTION
The repository can be included in the notifications with the --repo CLI option.

If no value is passed, the current working directory is used as the repository name. If a value is passed, it is used as the repository name.


---

When smart_todo is used in different repos, it's hard to tell which it is when a Slack notification comes in. This just adds a repo name, and requires no config (it uses the current working directory). If the CI system use a generic directory name, it's still possible to pass `--repo`. If that is unwanted, `--repo ""` can be passed to restore the previous behavior.

I hadn't seen #66 but now I realize that might be just better to pass a URL.

Also in terms of implementation, I started by adding the repo to the CommentParser, which passed it to the Todo objects it created, which the dispatchers could then use. But I scrapped that and use the CLI options directly from the dispatcher (since they're passed). It doesn't feel super clean but it's way simpler.