### PR TITLE
Implement comment format cop

### DIFF
--- a/lib/smart_todo_comment_format_cop.rb
+++ b/lib/smart_todo_comment_format_cop.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "smart_todo"
+require "parser"
+
+module RuboCop
+  module Cop
+    module SmartTodo
+      # A RuboCop cop to enforce proper formatting of SmartTodo comments.
+      # SmartTodo comments must have their description on separate lines, indented by 2 spaces.
+      #
+      # Bad:
+      #   # TODO(on: date('2024-03-29'), to: 'john@example.com'): Remove this
+      #   # TODO(on: date('2024-03-29'), to: 'john@example.com') Remove this
+      #   # TODO(on: date('2024-03-29'), to: 'john@example.com')
+      #   # Remove this (not indented)
+      #
+      # Good:
+      #   # TODO(on: date('2024-03-29'), to: 'john@example.com')
+      #   #   Remove this (indented by 2 extra spaces)
+      #
+      class SmartTodoCommentFormatCop < Base
+        extend AutoCorrector
+
+        MSG_INLINE = "SmartTodo comment must not be on the same line as the TODO. " \
+          "For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax"
+        MSG_INDENT = "SmartTodo continuation line must be indented by 2 spaces. " \
+          "For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax"
+
+        SMART_TODO_PATTERN = /\A\s*#\s*(TODO|FIXME|OPTIMIZE)\(on:/
+        INLINE_TEXT_PATTERN = /\A(\s*#\s*(?:TODO|FIXME|OPTIMIZE)\(.+\))\s*:?\s+(.+)/
+
+        def on_new_investigation
+          processed_source.comments.each_with_index do |comment, index|
+            next unless smart_todo_comment?(comment)
+
+            check_inline_text(comment)
+            check_continuation_indent(comment, processed_source.comments[index + 1])
+          end
+        end
+
+        private
+
+        def smart_todo_comment?(comment)
+          comment.text.match?(SMART_TODO_PATTERN)
+        end
+
+        def check_inline_text(comment)
+          match = comment.text.match(INLINE_TEXT_PATTERN)
+          return unless match
+
+          add_offense(comment.location.expression, message: MSG_INLINE) do |corrector|
+            todo_part = match[1]
+            text_part = match[2]
+            indentation = " " * comment.location.column
+
+            corrected = "#{todo_part}\n#{indentation}#   #{text_part}"
+            corrector.replace(comment.location.expression, corrected)
+          end
+        end
+
+        def check_continuation_indent(comment, next_comment)
+          return unless next_comment
+          return unless next_comment.location.line == comment.location.line + 1
+          return if smart_todo_comment?(next_comment)
+          return if empty_comment?(next_comment)
+          return if properly_indented?(next_comment)
+
+          add_offense(next_comment.location.expression, message: MSG_INDENT) do |corrector|
+            corrected = fix_indentation(next_comment.text)
+            corrector.replace(next_comment.location.expression, corrected)
+          end
+        end
+
+        def empty_comment?(comment)
+          comment.text.match?(/\A\s*#\s*\z/)
+        end
+
+        def properly_indented?(comment)
+          # A properly indented continuation has exactly 2 spaces after the #
+          comment.text.match?(/\A\s*#   \S/)
+        end
+
+        def fix_indentation(text)
+          # Extract leading whitespace and content
+          match = text.match(/\A(\s*)#\s*(\S.*)\z/)
+          return text unless match
+
+          leading_space = match[1]
+          content = match[2]
+          "#{leading_space}#   #{content}"
+        end
+      end
+    end
+  end
+end

--- a/test/smart_todo/smart_todo_comment_format_cop_test.rb
+++ b/test/smart_todo/smart_todo_comment_format_cop_test.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rubocop"
+require "rubocop/rspec/expect_offense"
+require "smart_todo_comment_format_cop"
+
+module SmartTodo
+  class SmartTodoCommentFormatCopTest < Minitest::Test
+    def test_add_offense_when_comment_on_same_line_with_colon
+      expect_offense(<<~RUBY)
+        # TODO(on: date('2024-03-29'), to: 'john@example.com'): Remove this
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{msg_inline}
+        def hello
+        end
+      RUBY
+    end
+
+    def test_add_offense_when_comment_on_same_line_without_colon
+      expect_offense(<<~RUBY)
+        # TODO(on: date('2024-03-29'), to: 'john@example.com') Remove this
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{msg_inline}
+        def hello
+        end
+      RUBY
+    end
+
+    def test_add_offense_when_continuation_line_not_indented
+      expect_offense(<<~RUBY)
+        # TODO(on: date('2024-03-29'), to: 'john@example.com')
+        # Remove this
+        ^^^^^^^^^^^^^ #{msg_indent}
+        def hello
+        end
+      RUBY
+    end
+
+    def test_add_offense_when_continuation_line_partially_indented
+      expect_offense(<<~RUBY)
+        # TODO(on: date('2024-03-29'), to: 'john@example.com')
+        #  Remove this (only 1 space instead of 2)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{msg_indent}
+        def hello
+        end
+      RUBY
+    end
+
+    def test_does_not_add_offense_when_properly_formatted
+      expect_no_offense(<<~RUBY)
+        # TODO(on: date('2024-03-29'), to: 'john@example.com')
+        #   Remove this
+        def hello
+        end
+      RUBY
+    end
+
+    def test_does_not_add_offense_when_no_continuation_line
+      expect_no_offense(<<~RUBY)
+        # TODO(on: date('2024-03-29'), to: 'john@example.com')
+        def hello
+        end
+      RUBY
+    end
+
+    def test_does_not_add_offense_when_continuation_line_is_empty
+      expect_no_offense(<<~RUBY)
+        # TODO(on: date('2024-03-29'), to: 'john@example.com')
+        #
+        def hello
+        end
+      RUBY
+    end
+
+    def test_does_not_add_offense_when_continuation_is_another_todo
+      expect_no_offense(<<~RUBY)
+        # TODO(on: date('2024-03-29'), to: 'john@example.com')
+        # FIXME(on: date('2024-04-01'), to: 'jane@example.com')
+        def hello
+        end
+      RUBY
+    end
+
+    def test_autocorrect_inline_comment_with_colon
+      expect_correction(
+        <<~RUBY,
+          # TODO(on: date('2024-03-29'), to: 'john@example.com'): Remove this
+          def hello
+          end
+        RUBY
+        <<~RUBY,
+          # TODO(on: date('2024-03-29'), to: 'john@example.com')
+          #   Remove this
+          def hello
+          end
+        RUBY
+      )
+    end
+
+    def test_autocorrect_inline_comment_without_colon
+      expect_correction(
+        <<~RUBY,
+          # TODO(on: date('2024-03-29'), to: 'john@example.com') Remove this
+          def hello
+          end
+        RUBY
+        <<~RUBY,
+          # TODO(on: date('2024-03-29'), to: 'john@example.com')
+          #   Remove this
+          def hello
+          end
+        RUBY
+      )
+    end
+
+    def test_autocorrect_unindented_continuation
+      expect_correction(
+        <<~RUBY,
+          # TODO(on: date('2024-03-29'), to: 'john@example.com')
+          # Remove this
+          def hello
+          end
+        RUBY
+        <<~RUBY,
+          # TODO(on: date('2024-03-29'), to: 'john@example.com')
+          #   Remove this
+          def hello
+          end
+        RUBY
+      )
+    end
+
+    def test_autocorrect_partially_indented_continuation
+      expect_correction(
+        <<~RUBY,
+          # TODO(on: date('2024-03-29'), to: 'john@example.com')
+          #  Remove this
+          def hello
+          end
+        RUBY
+        <<~RUBY,
+          # TODO(on: date('2024-03-29'), to: 'john@example.com')
+          #   Remove this
+          def hello
+          end
+        RUBY
+      )
+    end
+
+    def test_works_with_fixme_tag
+      expect_offense(<<~RUBY)
+        # FIXME(on: date('2024-03-29'), to: 'john@example.com'): Fix this
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{msg_inline}
+        def hello
+        end
+      RUBY
+    end
+
+    def test_works_with_optimize_tag
+      expect_offense(<<~RUBY)
+        # OPTIMIZE(on: date('2024-03-29'), to: 'john@example.com'): Optimize this
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{msg_inline}
+        def hello
+        end
+      RUBY
+    end
+
+    def test_multiline_continuation_properly_formatted
+      expect_no_offense(<<~RUBY)
+        # TODO(on: date('2024-03-29'), to: 'john@example.com')
+        #   Remove pre_launch_enabled from settings
+        #   and update the tests accordingly
+        def hello
+        end
+      RUBY
+    end
+
+    def test_multiline_continuation_improperly_formatted
+      expect_offense(<<~RUBY)
+        # TODO(on: date('2024-03-29'), to: 'john@example.com')
+        # Remove pre_launch_enabled from settings
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{msg_indent}
+        # and update the tests accordingly
+        def hello
+        end
+      RUBY
+    end
+
+    private
+
+    def msg_inline
+      "SmartTodo/SmartTodoCommentFormatCop: SmartTodo comment must not be on the same line as the TODO. " \
+        "For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax"
+    end
+
+    def msg_indent
+      "SmartTodo/SmartTodoCommentFormatCop: SmartTodo continuation line must be indented by 2 spaces. " \
+        "For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax"
+    end
+
+    def expect_offense(source)
+      annotated_source = RuboCop::RSpec::ExpectOffense::AnnotatedSource.parse(source)
+      report = investigate(annotated_source.plain_source)
+
+      actual_annotations = annotated_source.with_offense_annotations(report.offenses)
+      assert_equal(annotated_source.to_s, actual_annotations.to_s)
+    end
+
+    def expect_no_offense(source)
+      annotated_source = RuboCop::RSpec::ExpectOffense::AnnotatedSource.parse(source)
+      report = investigate(annotated_source.plain_source)
+
+      assert_empty(report.offenses, "Expected no offenses but got: #{report.offenses.map(&:message).join(", ")}")
+    end
+
+    def expect_correction(source, expected)
+      file = "(file)"
+      processed_source = RuboCop::ProcessedSource.new(source, RUBY_VERSION.to_f, file)
+
+      assert(processed_source.valid_syntax?)
+
+      comm = RuboCop::Cop::Commissioner.new([cop], [], raise_error: true)
+      report = comm.investigate(processed_source)
+
+      # Apply corrections
+      corrector = RuboCop::Cop::Corrector.new(processed_source)
+      report.offenses.each do |offense|
+        corrector.merge!(offense.corrector) if offense.corrector
+      end
+
+      corrected_source = corrector.rewrite
+
+      assert_equal(expected, corrected_source)
+    end
+
+    def investigate(source, file = "(file)")
+      processed_source = RuboCop::ProcessedSource.new(source, RUBY_VERSION.to_f, file)
+
+      assert(processed_source.valid_syntax?)
+      comm = RuboCop::Cop::Commissioner.new([cop], [], raise_error: true)
+      comm.investigate(processed_source)
+    end
+
+    def cop
+      # Always create a new cop instance to avoid state issues
+      RuboCop::Cop::SmartTodo::SmartTodoCommentFormatCop.new
+    end
+  end
+end


### PR DESCRIPTION
If someone writes a comment under a TODO but does not indent it, the comment will not be listed and then the todo is empty and doesn't make sense.

This cop notifies the user if the todo format is incorrect. In addition I've implemented an autocorrect which I ran on core and fixed over 800 incorrectly formatted todo comments.