### PR TITLE
Prepare for `1.11.0` release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smart_todo (1.10.0)
+    smart_todo (1.11.0)
       prism (~> 1.0)
 
 GEM

--- a/lib/smart_todo/version.rb
+++ b/lib/smart_todo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SmartTodo
-  VERSION = "1.10.0"
+  VERSION = "1.11.0"
 end


### PR DESCRIPTION
Bumping `Minor` version for the introduction of  `context` attribute

This is patterned on https://github.com/Shopify/smart_todo/commit/00f663bfb745d33aca8b5e0bd8efd1c60035bb26