### PR TITLE
Tag comment owner on Slack message

### DIFF
--- a/lib/smart_todo.rb
+++ b/lib/smart_todo.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "open3"
 require "prism"
 require "smart_todo/version"
 require "smart_todo/events"
@@ -10,6 +11,7 @@ module SmartTodo
   autoload :Todo,                     "smart_todo/todo"
   autoload :CommentParser,            "smart_todo/comment_parser"
   autoload :HttpClientBuilder,        "smart_todo/http_client_builder"
+  autoload :GitBlame,                 "smart_todo/git_blame"
 
   module Dispatchers
     autoload :Base,                   "smart_todo/dispatchers/base"

--- a/lib/smart_todo/comment_parser.rb
+++ b/lib/smart_todo/comment_parser.rb
@@ -59,7 +59,7 @@ module SmartTodo
 
         if source.match?(TAG_PATTERN)
           todos << current_todo if current_todo
-          current_todo = Todo.new(source, filepath)
+          current_todo = Todo.new(source, filepath, start_line: comment.location.start_line)
         elsif current_todo && (indent = source[/^#(\s*)/, 1].length) && (indent - current_todo.indent == 2)
           current_todo << "#{source[(indent + 1)..]}\n"
         else

--- a/lib/smart_todo/dispatchers/base.rb
+++ b/lib/smart_todo/dispatchers/base.rb
@@ -57,18 +57,21 @@ module SmartTodo
       #
       # @param user [Hash] contain information about a user
       # @param assignee [String] original string handle the slack message should be sent
+      # @param owner [String, nil] optional Slack user ID of the TODO owner (from git blame)
       # @return [String]
-      def slack_message(user, assignee)
+      def slack_message(user, assignee, owner: nil)
         header = if user.key?("fallback")
           unexisting_user(assignee)
         else
           existing_user
         end
 
+        owner_line = owner ? "\nOwner: <@#{owner}>\n" : ""
+
         <<~EOM
           #{header}
 
-          You have an assigned TODO in the `#{@file}` file#{repo}.
+          You have an assigned TODO in the `#{@file}` file#{repo}.#{owner_line}
           #{@event_message}
 
           Here is the associated comment on your TODO:

--- a/lib/smart_todo/dispatchers/slack.rb
+++ b/lib/smart_todo/dispatchers/slack.rb
@@ -21,8 +21,9 @@ module SmartTodo
       #
       # @return [Array] Slack response for each assignee a message was sent to
       def dispatch
+        owner_slack_id = lookup_todo_owner
         @assignees.each do |assignee|
-          dispatch_one(assignee)
+          dispatch_one(assignee, owner_slack_id)
         end
       end
 
@@ -31,15 +32,16 @@ module SmartTodo
       # @raise [SlackClient::Error] in case the Slack API returns an error
       #   other than `users_not_found`
       #
-      # @param [String] the assignee handle string
+      # @param assignee [String] the assignee handle string
+      # @param owner_slack_id [String, nil] the Slack user ID of the TODO owner
       # @return [Hash] the Slack response
-      def dispatch_one(assignee)
+      def dispatch_one(assignee, owner_slack_id = nil)
         user = slack_user_or_channel(assignee)
 
         return unless user
 
         begin
-          client.post_message(user.dig("user", "id"), slack_message(user, assignee))
+          client.post_message(user.dig("user", "id"), slack_message(user, assignee, owner: owner_slack_id))
         rescue SlackClient::Error => error
           user = handle_slack_error(error, "Error dispatching message")
           retry
@@ -50,6 +52,21 @@ module SmartTodo
       end
 
       private
+
+      # Look up the Slack user ID of the person who added the TODO comment
+      # using git blame to find the author's email.
+      #
+      # @return [String, nil] the Slack user ID, or nil if not found
+      def lookup_todo_owner
+        author_email = GitBlame.author_email(@file, @todo_node.start_line)
+        return unless author_email
+
+        response = client.lookup_user_by_email(author_email)
+        response.dig("user", "id")
+      rescue SlackClient::Error, Net::HTTPError
+        # If we can't find the owner, just skip including them in the message
+        nil
+      end
 
       # Returns a formatted hash containing either the user id of a slack user or
       # the channel the message should be sent to.

--- a/lib/smart_todo/git_blame.rb
+++ b/lib/smart_todo/git_blame.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module SmartTodo
+  # A helper class to extract git blame information for a specific line in a file.
+  class GitBlame
+    class << self
+      # Get the author email for a specific line in a file using git blame.
+      #
+      # @param filepath [String] the path to the file
+      # @param line_number [Integer] the line number to blame
+      # @return [String, nil] the author email, or nil if git blame fails
+      def author_email(filepath, line_number)
+        return unless filepath && line_number
+
+        output = run_git_blame(filepath, line_number)
+        return unless output
+
+        extract_email(output)
+      end
+
+      private
+
+      # Run git blame for a specific line and return the output.
+      #
+      # @param filepath [String] the path to the file
+      # @param line_number [Integer] the line number to blame
+      # @return [String, nil] the git blame output, or nil if the command fails
+      def run_git_blame(filepath, line_number)
+        # Use -L to specify the line range, -e to show email, --porcelain for easy parsing
+        command = ["git", "blame", "-L", "#{line_number},#{line_number}", "--porcelain", "--", filepath]
+
+        output, status = Open3.capture2(*command)
+        return unless status.success?
+
+        output
+      rescue Errno::ENOENT
+        # git command not found
+        nil
+      end
+
+      # Extract the author email from git blame porcelain output.
+      #
+      # @param output [String] the git blame porcelain output
+      # @return [String, nil] the author email, or nil if not found
+      def extract_email(output)
+        output.each_line do |line|
+          next unless line.start_with?("author-mail ")
+
+          # The format is "author-mail <email@example.com>"
+          email = line.sub("author-mail ", "").strip
+          # Remove angle brackets
+          return email.tr("<>", "")
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/smart_todo/todo.rb
+++ b/lib/smart_todo/todo.rb
@@ -2,12 +2,13 @@
 
 module SmartTodo
   class Todo
-    attr_reader :filepath, :comment, :indent
+    attr_reader :filepath, :comment, :indent, :start_line
     attr_reader :events, :assignees, :errors
     attr_accessor :context
 
-    def initialize(source, filepath = "-e")
+    def initialize(source, filepath = "-e", start_line: nil)
       @filepath = filepath
+      @start_line = start_line
       @comment = +""
       @indent = source[/^#(\s+)/, 1].length
 

--- a/test/smart_todo/git_blame_test.rb
+++ b/test/smart_todo/git_blame_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tempfile"
+
+module SmartTodo
+  class GitBlameTest < Minitest::Test
+    def test_returns_nil_when_filepath_is_nil
+      assert_nil(GitBlame.author_email(nil, 1))
+    end
+
+    def test_returns_nil_when_line_number_is_nil
+      assert_nil(GitBlame.author_email("some_file.rb", nil))
+    end
+
+    def test_returns_nil_when_file_is_not_in_git_repo
+      Tempfile.create("test_file.rb") do |file|
+        file.write("# some content\n")
+        file.flush
+
+        assert_nil(GitBlame.author_email(file.path, 1))
+      end
+    end
+
+    def test_returns_author_email_for_file_in_repo
+      # Use an actual file in the smart_todo repo
+      filepath = File.expand_path("../../lib/smart_todo/version.rb", __dir__)
+      email = GitBlame.author_email(filepath, 1)
+
+      assert_match(/@/, email, "Expected email to contain @") if email
+    end
+
+    def test_returns_nil_when_git_command_not_found
+      # Temporarily modify PATH to simulate git not being available
+      original_path = ENV["PATH"]
+      ENV["PATH"] = ""
+
+      assert_nil(GitBlame.author_email("some_file.rb", 1))
+    ensure
+      ENV["PATH"] = original_path
+    end
+  end
+end


### PR DESCRIPTION
## Add TODO owner to Slack notifications

This PR adds an `Owner: @user` field to Slack notifications, identifying who originally added the TODO comment.

### Why?

TODO notifications can flood a Slack channel. Without knowing who wrote each TODO, someone has to manually `git blame` every one to find the owner and tag them for context. This adds the owner automatically.

### How it works

1. When a TODO is due, we use `git blame` to find who added the line
2. Extract the author's email from the commit
3. Look up the Slack user by email using the existing `lookup_user_by_email` API
4. Include `Owner: <@SLACK_USER_ID>` in the message (creates a clickable mention that notifies the user)

### Example output

```diff
Hello :wave:,

You have an assigned TODO in the `./app/services/example.rb` file.
+ Owner: @John Doe

...
```

### Changes

- **`GitBlame`** - New class to extract author email via `git blame --porcelain`
- **`Todo`** - Added `start_line` attribute to track TODO location
- **`Slack` dispatcher** - Looks up owner and includes in message
- Gracefully handles failures (missing git, user not found) by omitting the Owner field

### Caveats

git blame might not be the most reliable though. If someone edits or moves the comment they become the owner. Maybe a new cop to require "owner" if the assignee is not a person would be better?