### PR TITLE
Add cop for owner when any assignee is a channel

### DIFF
--- a/lib/smart_todo/dispatchers/base.rb
+++ b/lib/smart_todo/dispatchers/base.rb
@@ -57,18 +57,21 @@ module SmartTodo
       #
       # @param user [Hash] contain information about a user
       # @param assignee [String] original string handle the slack message should be sent
+      # @param owner_slack_id [String, nil] the Slack user ID of the TODO owner
       # @return [String]
-      def slack_message(user, assignee)
+      def slack_message(user, assignee, owner_slack_id: nil)
         header = if user.key?("fallback")
           unexisting_user(assignee)
         else
           existing_user
         end
 
+        owner_line = owner_slack_id ? "\nOwner: <@#{owner_slack_id}>\n" : ""
+
         <<~EOM
           #{header}
 
-          You have an assigned TODO in the `#{@file}` file#{repo}.
+          You have an assigned TODO in the `#{@file}` file#{repo}.#{owner_line}
           #{@event_message}
 
           Here is the associated comment on your TODO:

--- a/lib/smart_todo/dispatchers/slack.rb
+++ b/lib/smart_todo/dispatchers/slack.rb
@@ -21,8 +21,9 @@ module SmartTodo
       #
       # @return [Array] Slack response for each assignee a message was sent to
       def dispatch
+        owner_slack_id = lookup_owner
         @assignees.each do |assignee|
-          dispatch_one(assignee)
+          dispatch_one(assignee, owner_slack_id)
         end
       end
 
@@ -31,15 +32,16 @@ module SmartTodo
       # @raise [SlackClient::Error] in case the Slack API returns an error
       #   other than `users_not_found`
       #
-      # @param [String] the assignee handle string
+      # @param assignee [String] the assignee handle string
+      # @param owner_slack_id [String, nil] the Slack user ID of the TODO owner
       # @return [Hash] the Slack response
-      def dispatch_one(assignee)
+      def dispatch_one(assignee, owner_slack_id = nil)
         user = slack_user_or_channel(assignee)
 
         return unless user
 
         begin
-          client.post_message(user.dig("user", "id"), slack_message(user, assignee))
+          client.post_message(user.dig("user", "id"), slack_message(user, assignee, owner_slack_id: owner_slack_id))
         rescue SlackClient::Error => error
           user = handle_slack_error(error, "Error dispatching message")
           retry
@@ -50,6 +52,18 @@ module SmartTodo
       end
 
       private
+
+      # Look up the Slack user ID for the TODO owner.
+      #
+      # @return [String, nil] the Slack user ID, or nil if no owner specified
+      def lookup_owner
+        return unless @todo_node.owner
+
+        response = client.lookup_user_by_email(@todo_node.owner)
+        response.dig("user", "id")
+      rescue SlackClient::Error, Net::HTTPError
+        nil
+      end
 
       # Returns a formatted hash containing either the user id of a slack user or
       # the channel the message should be sent to.

--- a/lib/smart_todo/todo.rb
+++ b/lib/smart_todo/todo.rb
@@ -4,7 +4,7 @@ module SmartTodo
   class Todo
     attr_reader :filepath, :comment, :indent
     attr_reader :events, :assignees, :errors
-    attr_accessor :context
+    attr_accessor :context, :owner
 
     def initialize(source, filepath = "-e")
       @filepath = filepath
@@ -14,6 +14,7 @@ module SmartTodo
       @events = []
       @assignees = []
       @context = nil
+      @owner = nil
       @errors = []
 
       parse(source[(indent + 1)..])
@@ -68,6 +69,14 @@ module SmartTodo
             end
           when :to
             metadata.assignees << visit(element.value)
+          when :owner
+            value = visit(element.value)
+
+            if value.is_a?(String) && value.include?("@")
+              metadata.owner = value
+            else
+              metadata.errors << "Incorrect `:owner` format: expected email address"
+            end
           when :context
             value = visit(element.value)
 

--- a/test/smart_todo/metadata_parser_test.rb
+++ b/test/smart_todo/metadata_parser_test.rb
@@ -113,6 +113,45 @@ module SmartTodo
         assert_empty(result.events)
         assert_empty(result.assignees)
       end
+
+      def test_parse_todo_metadata_with_owner
+        ruby_code = <<~RUBY
+          # TODO(on: date('2019-08-04'), to: '#my-channel', owner: 'jane@example.com')
+        RUBY
+
+        result = Todo.new(ruby_code)
+        assert_equal("jane@example.com", result.owner)
+        assert_empty(result.errors)
+      end
+
+      def test_parse_todo_metadata_without_owner
+        ruby_code = <<~RUBY
+          # TODO(on: date('2019-08-04'), to: 'john@example.com')
+        RUBY
+
+        result = Todo.new(ruby_code)
+        assert_nil(result.owner)
+      end
+
+      def test_parse_todo_metadata_with_invalid_owner_not_email
+        ruby_code = <<~RUBY
+          # TODO(on: date('2019-08-04'), to: '#my-channel', owner: 'john')
+        RUBY
+
+        result = Todo.new(ruby_code)
+        assert_nil(result.owner)
+        assert_equal(["Incorrect `:owner` format: expected email address"], result.errors)
+      end
+
+      def test_parse_todo_metadata_with_invalid_owner_not_string
+        ruby_code = <<~RUBY
+          # TODO(on: date('2019-08-04'), to: '#my-channel', owner: 123)
+        RUBY
+
+        result = Todo.new(ruby_code)
+        assert_nil(result.owner)
+        assert_equal(["Incorrect `:owner` format: expected email address"], result.errors)
+      end
     end
   end
 end

--- a/test/smart_todo/smart_todo_cop_test.rb
+++ b/test/smart_todo/smart_todo_cop_test.rb
@@ -135,7 +135,7 @@ module SmartTodo
 
     def test_does_not_add_offense_when_todo_assignee_is_a_list_of_strings
       expect_no_offense(<<~RUBY)
-        # TODO(on: date('2019-08-04'), to: '#foo', to: '#bar')
+        # TODO(on: date('2019-08-04'), to: '#foo', to: '#bar', owner: 'john@example.com')
         def hello
         end
       RUBY
@@ -543,6 +543,67 @@ module SmartTodo
       expect_offense(<<~RUBY)
         # TODO(on: date('2019-08-04'), context: "shopify/smart_todo#123")
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{expected_message}
+        def hello
+        end
+      RUBY
+    end
+
+    def test_add_offense_when_todo_is_assigned_to_channel_without_owner
+      expect_offense(<<~RUBY)
+        # TODO(on: date('2019-08-04'), to: '#my-channel')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SmartTodo/SmartTodoCop: Missing `owner:` option. When assigning to a channel, you must specify an owner. For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax
+        def hello
+        end
+      RUBY
+    end
+
+    def test_does_not_add_offense_when_todo_is_assigned_to_channel_with_owner
+      expect_no_offense(<<~RUBY)
+        # TODO(on: date('2019-08-04'), to: '#my-channel', owner: 'john@example.com')
+        def hello
+        end
+      RUBY
+    end
+
+    def test_does_not_add_offense_when_todo_is_assigned_to_email_without_owner
+      expect_no_offense(<<~RUBY)
+        # TODO(on: date('2019-08-04'), to: 'john@example.com')
+        def hello
+        end
+      RUBY
+    end
+
+    def test_add_offense_when_todo_has_mixed_assignees_without_owner
+      # If any assignee is a channel, owner is required
+      expect_offense(<<~RUBY)
+        # TODO(on: date('2019-08-04'), to: '#my-channel', to: 'john@example.com')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SmartTodo/SmartTodoCop: Missing `owner:` option. When assigning to a channel, you must specify an owner. For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax
+        def hello
+        end
+      RUBY
+    end
+
+    def test_does_not_add_offense_when_todo_has_mixed_assignees_with_owner
+      expect_no_offense(<<~RUBY)
+        # TODO(on: date('2019-08-04'), to: '#my-channel', to: 'john@example.com', owner: 'jane@example.com')
+        def hello
+        end
+      RUBY
+    end
+
+    def test_add_offense_when_owner_is_not_an_email
+      expect_offense(<<~RUBY)
+        # TODO(on: date('2019-08-04'), to: '#my-channel', owner: 'john')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SmartTodo/SmartTodoCop: Invalid TODO format: Incorrect `:owner` format: expected email address. For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax
+        def hello
+        end
+      RUBY
+    end
+
+    def test_add_offense_when_owner_is_not_a_string
+      expect_offense(<<~RUBY)
+        # TODO(on: date('2019-08-04'), to: '#my-channel', owner: 123)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SmartTodo/SmartTodoCop: Invalid TODO format: Incorrect `:owner` format: expected email address. For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax
         def hello
         end
       RUBY


### PR DESCRIPTION
## Add `owner:` option

### Why

When many TODOs expire at once, notifications flood a Slack channel. Without knowing who wrote each TODO, someone has to manually track down the original author to get context.

### What

Adds an explicit `owner:` option to SmartTodo comments. When a TODO is assigned to a channel, the cop now requires specifying an owner (email). The owner is then mentioned in the Slack notification.

**Syntax:**
```ruby
# TODO(on: date('2025-01-01'), to: '#payments-team', owner: 'jane@example.com')
#   Remove feature flag after launch
```

**Slack message:**
```
Hello :wave:,

You have an assigned TODO in the `./app/services/example.rb` file.
Owner: @Jane Doe

We are past the 2025-01-01 due date and your TODO is now ready to be addressed.
...
```

### Rules

- `owner:` is **required** when any assignee is a channel (`#...`)
- `owner:` is **optional** when all assignees are emails
- `owner:` must be a valid email address