### PR TITLE
Ignore empty comments in slack message

### DIFF
--- a/lib/smart_todo/dispatchers/base.rb
+++ b/lib/smart_todo/dispatchers/base.rb
@@ -65,18 +65,26 @@ module SmartTodo
           existing_user
         end
 
-        <<~EOM
+        message = <<~EOM
           #{header}
 
           You have an assigned TODO in the `#{@file}` file#{repo}.
           #{@event_message}
-
-          Here is the associated comment on your TODO:
-
-          ```
-          #{@todo_node.comment.strip}
-          ```
         EOM
+
+        comment = @todo_node.comment.strip
+        unless comment.empty?
+          message += <<~EOM
+
+            Here is the associated comment on your TODO:
+
+            ```
+            #{comment}
+            ```
+          EOM
+        end
+
+        message
       end
 
       # Message in case a TODO's assignee doesn't exist in the Slack organization

--- a/test/smart_todo/dispatchers/output_test.rb
+++ b/test/smart_todo/dispatchers/output_test.rb
@@ -16,12 +16,6 @@ module SmartTodo
 
           You have an assigned TODO in the `file.rb` file in repository `example`.
           Foo
-
-          Here is the associated comment on your TODO:
-
-          ```
-
-          ```
         HEREDOC
 
         assert_output(expected_text) { dispatcher.dispatch }


### PR DESCRIPTION
If there is no attached comment to the smart TODO, or if it is misaligned, it is not added to the Slack message. However an empty markdown block _is_ added.

For example [this Slack message](https://shopify.slack.com/archives/C066CG6KH40/p1760353662397489) rendered as 

<img width="599" height="255" alt="smart-todo" src="https://github.com/user-attachments/assets/a0cf51e4-2b36-4d30-86e4-63e4c84dbb12" />

This occurred because [the TODO comment](https://github.com/shop/world/blob/918ff97b5e321a6156dd9cd01b4f2682855cffdb/areas/core/shopify/components/online_store/app/models/online_store_editor/theme_generation.rb#L25) was not correctly indented

```
        # TODO(on: date('2025-10-07'), to: '#growth-ai-tooling-team')
        #  Move this to a mutation to be triggered by online store web.
```
(one space between `#` and `Move` instead of 2)

Update the Slack message to only show the "comment" if a comment was parsed.